### PR TITLE
Exclude property slugs

### DIFF
--- a/attachments/forms.py
+++ b/attachments/forms.py
@@ -39,7 +39,7 @@ class PropertyForm (forms.Form):
 
     def __init__(self, *args, **kwargs):
         instance = kwargs.pop('instance')
-
+        excluded_slugs = kwargs.pop("excluded_slugs", [])
         content_type = None
         if isinstance(instance, Attachment):
             content_type = instance.content_type
@@ -48,7 +48,7 @@ class PropertyForm (forms.Form):
 
         super(PropertyForm, self).__init__(*args, **kwargs)
 
-        for prop in Property.objects.filter(content_type=content_type):
+        for prop in Property.objects.exclude(slug__in=excluded_slugs).filter(content_type=content_type):
             if isinstance(instance, Upload):
                 field_key = 'upload-%d-%s' % (instance.pk, prop.slug)
                 self.fields[field_key] = self.formfield(prop,

--- a/attachments/templates/attachments/edit_properties.html
+++ b/attachments/templates/attachments/edit_properties.html
@@ -2,7 +2,7 @@
 
 <div class="popover">
     <div class="arrow"></div>
-    <form action="{% url "update-attachment" attach_id=att.pk %}" method="post" class="update-attachment">
+    <form action="{% url "update-attachment" attach_id=att.pk %}?{{ querystring }}" method="post" class="update-attachment">
         {% csrf_token %}
         <div class="popover-title">
             <button type="button" class="close" aria-hidden="true" data-dismiss="popover"><span class="fa fa-times" aria-hidden="true"></span><span class="sr-only">Close</span></button>

--- a/attachments/templatetags/attachments.py
+++ b/attachments/templatetags/attachments.py
@@ -23,9 +23,11 @@ def has_edditable_attachment_properties(content_type, excluded_slugs=""):
     excluded_slugs = excluded_slugs.split(",") if excluded_slugs else getattr(settings, "ATTACHMENTS_EDIT_EXCLUDE_PROPERTY_SLUGS", [])
     return Property.objects.exclude(slug__in=excluded_slugs).filter(content_type=content_type).exists()
 
+
 @register.filter
 def attachment_properties_form(obj):
     return PropertyForm(instance=obj)
+
 
 @register.simple_tag
 def attachment_properties_form(obj, excluded_slugs=""):

--- a/attachments/templatetags/attachments.py
+++ b/attachments/templatetags/attachments.py
@@ -1,4 +1,5 @@
 from django import template
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 
 from ..forms import PropertyForm
@@ -16,5 +17,17 @@ def has_attachment_properties(content_type):
 
 
 @register.filter
-def attachment_properties_form(obj, content_type=None):
-    return PropertyForm(instance=obj, content_type=content_type)
+def has_edditable_attachment_properties(content_type, excluded_slugs=""):
+    if not isinstance(content_type, ContentType):
+        content_type = ContentType.objects.get_for_model(content_type)
+    excluded_slugs = excluded_slugs.split(",") if excluded_slugs else getattr(settings, "ATTACHMENTS_EDIT_EXCLUDE_PROPERTY_SLUGS", [])
+    return Property.objects.exclude(slug__in=excluded_slugs).filter(content_type=content_type).exists()
+
+@register.filter
+def attachment_properties_form(obj):
+    return PropertyForm(instance=obj)
+
+@register.simple_tag
+def attachment_properties_form(obj, excluded_slugs=""):
+    excluded_slugs = excluded_slugs.split(",") if excluded_slugs else getattr(settings, "ATTACHMENTS_EDIT_EXCLUDE_PROPERTY_SLUGS", [])
+    return PropertyForm(instance=obj, excluded_slugs=excluded_slugs)

--- a/attachments/views.py
+++ b/attachments/views.py
@@ -111,7 +111,8 @@ def update_attachment(request, attach_id):
         raise Http404()
     if request.is_ajax() and request.method == 'POST':
         try:
-            property_form = PropertyForm(request.POST, instance=attachment)
+            excluded_slugs= request.GET.getlist("excluded_slugs", []) or getattr(settings, "ATTACHMENTS_EDIT_EXCLUDE_PROPERTY_SLUGS", [])
+            property_form = PropertyForm(request.POST, instance=attachment, excluded_slugs=excluded_slugs)
             if property_form.is_valid():
                 attachment.data = attachment.extract_data(request)
                 attachment.save()
@@ -131,9 +132,11 @@ def edit_attachment_properties(request, attach_id):
     attachment = get_object_or_404(Attachment, pk=attach_id)
     if not user_has_access(request, attachment):
         raise Http404()
+    excluded_slugs= request.GET.getlist("excluded_slugs", []) or getattr(settings, "ATTACHMENTS_EDIT_EXCLUDE_PROPERTY_SLUGS", [])
     return render(request, 'attachments/edit_properties.html', {
         'att': attachment,
-        'form': PropertyForm(instance=attachment),
+        'querystring': request.GET.urlencode(),
+        'form': PropertyForm(instance=attachment, excluded_slugs=excluded_slugs),
     })
 
 


### PR DESCRIPTION
Allows sites to exclude particular properties from the properties form based on slug.