### PR TITLE
Update dep 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     install_requires=[
         'pyclamd',
         'python-magic',
-        'python-magic-bin',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     install_requires=[
         'pyclamd',
         'python-magic',
+        'python-magic-bin;platform_system=="Windows"',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
python-magic-bin can only be installed on Windows.