### PR TITLE
Session.extract_data was converting the querydict into a dictionary o…

### DIFF
--- a/attachments/models.py
+++ b/attachments/models.py
@@ -186,7 +186,7 @@ class Session (models.Model):
                 prefix = 'upload-%d-' % upload.pk
                 for key in self._request.POST:
                     if key.startswith(prefix):
-                        data[key] = self._request.POST.getlist(key)
+                        data[key] = self._request.POST.get(key)
         return data
 
     def set_data(self, extract_data=None, save=True):


### PR DESCRIPTION
Session.extract_data was converting the querydict into a dictionary of lists in order to add it to its jsonfield, howevever, this wraps values that should not be in lists, as per their cleaned representations from the property form, in lists. This fix assumes that there are no 'multi select' data types available to Property objects that would cause multiple values for any key into be passed into the POST data, which currently there are not.