### PR TITLE
1560 pass flag for form bind

### DIFF
--- a/attachments/forms.py
+++ b/attachments/forms.py
@@ -85,7 +85,7 @@ class PropertyForm (forms.Form):
         """
         form_data = {}
         if session_data is not None:
-            for key, val in session_data.iteritems():
+            for key, val in session_data.items():
                 if isinstance(val, (list, tuple)) and len(val) > 0:
                     form_val = val[0]
                 else:

--- a/attachments/models.py
+++ b/attachments/models.py
@@ -231,7 +231,9 @@ class Session (models.Model):
             valids.append(property_form.is_valid())
         # Commit the property data to the database
         self.set_data()
-        return all(valids)
+        is_valid = all(valids)
+        self.bind_form_on_refresh = is_valid
+        return is_valid
 
     @property
     def upload_forms(self):
@@ -246,6 +248,7 @@ class Session (models.Model):
                     for key in self.data:
                         # If the property_key_prefix exists in self.data, then we validate the form to show form errors
                         if key.startswith(property_key_prefix):
+                            property_form.is_bound = (self._request is not None and (self._request.method == 'POST' or self._request.GET.get('bind-form-data', False)))
                             property_form.is_valid()
                 yield None, upload, property_form
             else:

--- a/attachments/models.py
+++ b/attachments/models.py
@@ -232,7 +232,7 @@ class Session (models.Model):
         # Commit the property data to the database
         self.set_data()
         is_valid = all(valids)
-        self.bind_form_on_refresh = is_valid
+        self.bind_form_on_refresh = not is_valid
         return is_valid
 
     @property

--- a/attachments/static/attachments/js/attachments.js
+++ b/attachments/static/attachments/js/attachments.js
@@ -11,8 +11,14 @@
         }, options);
         
         var refresh = function() {
+        	var data = {};
+        	if (settings.container.hasClass('bind-form-on-refresh')) {
+        		data['bind-form-data'] = true;
+        		settings.container.removeClass('bind-form-on-refresh');
+        	}
             return $.ajax({
                 url: settings.url,
+                data: data,
                 success: function(html) {
                     $(settings.container).empty().append(html).trigger('table-changed');
                 }

--- a/attachments/views.py
+++ b/attachments/views.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 @csrf_exempt
 def attach(request, session_id):
     session = get_object_or_404(Session, uuid=session_id)
+    session._request = request
     if request.method == 'POST':
         # Old versions of IE doing iframe uploads would present a Save dialog on JSON responses.
         content_type = 'text/plain' if request.POST.get('X-Requested-With', '') == 'IFrame' else 'application/json'


### PR DESCRIPTION
The goal here is to allow the property form to load and show errors (if any) after it has been posted. It's a little round about in the attachments app, since the workflow is to post and then return html, but then to make an ajax get requests to get any pending session data for the attachments. So the form is not itself rendered to template in the post, but the later get. The get request builds the property form, and in some cases should bind the data so the form is validated (like directly after a post). In other cases it just needs to load the form and should not. Feel free to suggest an alternative approach. bioshare/attachments.html looks for the flag here - https://git.imsweb.com/bioshare/bioshare/merge_requests/722/diffs#2964017c5c1902925b9112133f5d8c1c2efc59b1_57_57 . 