### PR TITLE
NBB316 - updated get_field in Attachment model

### DIFF
--- a/attachments/models.py
+++ b/attachments/models.py
@@ -122,7 +122,9 @@ class Attachment (models.Model):
             Added for use in bootstrap's template tag render_value. Returns tuple of property label and value
         """
         if prop.data_type == 'model' and prop.slug in self.data:
-            return prop.label, prop.model_queryset().get(pk=self.data.get(prop.slug, [])[0])
+            pk = self.data.get(prop.slug, [])[0]
+            value = prop.model_queryset().get(pk=self.data.get(prop.slug, [])[0]) if pk else ''
+            return prop.label, value
         else:
             return prop.label, self.data.get(prop.slug, [])
 


### PR DESCRIPTION
@dcwatson heads up, let me know if you need any more info!  Brad and I discussed this solution yesterday to give us desired behavior on NBB but let me know if there is a better way to approach this / unintended consequences.

Related to https://git.imsweb.com/bioshare/neurobiobank/-/issues/316

By default, [attachments.models.Property has `required = True`](https://github.com/imsweb/django-dynamic-attachments/blob/3.0/attachments/models.py#L138).  This update will allow an Attachment to have a non-required Property, which will allow for the display of the Property's label even if the Property has no value set.

The need for this was discovered on NBB because we want to allow attachments to have an associated property 'request-document-type' with 'required=false', so we need a way to allow the property key to exist without (necessarily) having a value set on all Attachments.

Desired behavior with a value set:
![image](https://user-images.githubusercontent.com/27035676/101830637-d1c11f00-3b02-11eb-9a71-ff9f25cb4427.png)

Desired behavior with NO value set:
![image](https://user-images.githubusercontent.com/27035676/101830650-d8e82d00-3b02-11eb-9518-d5768a204750.png)

(The current behavior is the server error described in the NBB issue, and the user will not see any popup on the front end when clicking the 'View Properties' icon on an attachment.)