### PR TITLE
import python_2_unicode_compatible from six for django3.0 compatibility

### DIFF
--- a/attachments/models.py
+++ b/attachments/models.py
@@ -7,7 +7,6 @@ from django.core.files import File
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
-from six import python_2_unicode_compatible
 from django.utils.safestring import mark_safe
 
 from .signals import attachments_attached
@@ -55,7 +54,6 @@ class AttachmentManager (models.Manager):
         )
 
 
-@python_2_unicode_compatible
 class Attachment (models.Model):
     file_path = models.TextField(unique=True)
     file_name = models.CharField(max_length=200)
@@ -127,7 +125,6 @@ class Attachment (models.Model):
             return prop.label, self.data.get(prop.slug, [])
 
 
-@python_2_unicode_compatible
 class Property (models.Model):
     label = models.CharField(max_length=200)
     slug = models.SlugField(unique=True, help_text='Must be alphanumeric, with no spaces.')
@@ -161,7 +158,6 @@ class Property (models.Model):
         return qs
 
 
-@python_2_unicode_compatible
 class Session (models.Model):
     uuid = models.CharField(max_length=32, unique=True)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='attachment_sessions', null=True, blank=True, on_delete=models.SET_NULL)
@@ -323,7 +319,6 @@ class Session (models.Model):
                 raise VirusFoundException('**WARNING** virus: "{}" found in the file: "{}", could not upload!'.format(virus[upload.file_path][1], upload.file_name))
 
 
-@python_2_unicode_compatible
 class Upload (models.Model):
     session = models.ForeignKey(Session, related_name='uploads', on_delete=models.CASCADE)
     file_path = models.TextField(unique=True)

--- a/attachments/models.py
+++ b/attachments/models.py
@@ -7,7 +7,7 @@ from django.core.files import File
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.safestring import mark_safe
 
 from .signals import attachments_attached

--- a/attachments/utils.py
+++ b/attachments/utils.py
@@ -85,7 +85,7 @@ class JSONField (models.TextField):
             return json.loads(value)
         return value
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, expression, connection):
         return None if value is None else self.to_python(value)
 
     def get_prep_value(self, value):

--- a/attachments/utils.py
+++ b/attachments/utils.py
@@ -6,9 +6,8 @@ from django.db import IntegrityError, models
 from django.http import HttpResponse
 from os.path import exists
 from pyclamd import ClamdUnixSocket
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 from django.apps import apps
-import six
 import importlib
 import json
 import uuid
@@ -81,7 +80,7 @@ class JSONField (models.TextField):
     def to_python(self, value):
         if value == '':
             return None
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             return json.loads(value)
         return value
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'pyclamd',
-        'six',
         'python-magic',
         'python-magic-bin;platform_system=="Windows"',
     ],

--- a/testapp/requirements.txt
+++ b/testapp/requirements.txt
@@ -1,5 +1,4 @@
 Django>=1.11
-six
 coverage==3.7.1
 python-magic>=0.4.15
 python-magic-bin>=0.4.14


### PR DESCRIPTION
SEER is being upgraded to Django 3.2 (https://www.squishlist.com/ims/dal/21/), and making django-dynamic-attachments Django 3.0 compatible is the last roadblock for the upgrade. Started with just changing to import python_2_unicode_compatible from six since I wasn't sure if django-dynamic-attachments still requires Python 2 support, but let me know if I should just remove six completely.