### PR TITLE
2535 – Can access list of attachments via url without being logged in

### DIFF
--- a/attachments/__init__.py
+++ b/attachments/__init__.py
@@ -1,4 +1,4 @@
-__version_info__ = (3, 4, 0)
+__version_info__ = (3, 4, 1)
 __version__ = '.'.join(str(i) for i in __version_info__)
 
 

--- a/attachments/static/attachments/js/attachments.js
+++ b/attachments/static/attachments/js/attachments.js
@@ -108,6 +108,7 @@
             };
 
             xhr.open('POST', settings.url, true);
+            xhr.setRequestHeader('X-REQUESTED-WITH', 'XMLHttpRequest');
             xhr.send(formData);
 
             return signal;

--- a/attachments/utils.py
+++ b/attachments/utils.py
@@ -1,9 +1,11 @@
+from functools import wraps
+
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.storage import get_storage_class
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import IntegrityError, models
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
 from os.path import exists
 from pyclamd import ClamdUnixSocket
 from urllib.parse import quote
@@ -69,7 +71,6 @@ def url_filename(filename):
     return quote(filename.encode('utf-8'), safe='/ ')
 
 
-
 def user_has_access(request, attachment):
     # Proxy for backward compatibility
     return apps.get_app_config('attachments').user_has_access(request, attachment)
@@ -97,6 +98,7 @@ class JSONField (models.TextField):
     def value_to_string(self, obj):
         return self.get_prep_value(self.value_from_object(obj))
 
+
 def import_class(fq_name):
     module_name, class_name = fq_name.rsplit('.', 1)
     mod = importlib.import_module(module_name)
@@ -110,3 +112,18 @@ class Centos7ClamdUnixSocket(ClamdUnixSocket):
             filename = centos_7_socket
         super().__init__(filename, timeout)
 
+
+def is_ajax(request):
+    """Util function for checking if request is made with ajax"""
+    return request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest'
+
+
+def ajax_only(view_func):
+    """Ensures that view function is being called by ajax. Returns 404 if not."""
+    @wraps(view_func)
+    def wrapped_view(*args, **kwargs):
+        if is_ajax(args[0]):
+            return view_func(*args, **kwargs)
+        raise Http404()
+
+    return wrapped_view

--- a/attachments/utils.py
+++ b/attachments/utils.py
@@ -121,9 +121,9 @@ def is_ajax(request):
 def ajax_only(view_func):
     """Ensures that view function is being called by ajax. Returns 404 if not."""
     @wraps(view_func)
-    def wrapped_view(*args, **kwargs):
-        if is_ajax(args[0]):
-            return view_func(*args, **kwargs)
+    def wrapped_view(request, *args, **kwargs):
+        if is_ajax(request):
+            return view_func(request, *args, **kwargs)
         raise Http404()
 
     return wrapped_view


### PR DESCRIPTION
https://squishlist.com/ims/bioshare/2535/?home

Added an is_ajax utility function as the Django version is deprecated as well as a ajax_only decorator function to use with views.

In order to make is_ajax work I had to add the X_REQUESTED_WITH='XMLHttpRequest' in its request as it is not set by default.

Finally, attach and delete_upload were made ajax only and delete_upload checks for delete permission.