### PR TITLE
3803 only install python-magic if platform_system is not windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'pyclamd',
-        'python-magic',
+        'python-magic;platform_system!="Windows"',
         'python-magic-bin;platform_system=="Windows"',
     ],
     classifiers=[


### PR DESCRIPTION
modify setup.py to only install python-magic when platform_system != Windows