### PR TITLE
Update get_storage() for Django 5 compatibility

### DIFF
--- a/attachments/utils.py
+++ b/attachments/utils.py
@@ -2,10 +2,11 @@ from functools import wraps
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import storages
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import IntegrityError, models
 from django.http import Http404, HttpResponse
+from django.utils.module_loading import import_string
 from os.path import exists
 from pyclamd import ClamdUnixSocket
 from urllib.parse import quote
@@ -65,9 +66,10 @@ def session(request, template=get_template_path(filename='list.html'), context='
 
 
 def get_storage():
-    cls, kwargs = getattr(settings, 'ATTACHMENT_STORAGE', (settings.DEFAULT_FILE_STORAGE, {}))
-    return get_storage_class(cls)(**kwargs)
-
+    cls_dict = storages.backends.get('attachment_storage', storages.backends["default"])
+    storage_class = import_string(cls_dict["BACKEND"])
+    storage_options = cls_dict.get("OPTIONS", {})
+    return storage_class(**storage_options)
 
 def get_default_path(upload, obj):
     ct = ContentType.objects.get_for_model(obj)


### PR DESCRIPTION
get_storage() was updated to use the new storages settings that's encouraged in Django 5: https://docs.djangoproject.com/en/5.2/ref/files/storage/#django.core.files.storage.storages.

The project's settings file would need to be updated to add:

`
STORAGES = {
    "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
    "attachment_storage": {
        "BACKEND": "pzip_storage.PZipStorage",
        "OPTIONS": {"location": BASE_DIR},
    },
}
`

Or whatever the project's appropriate backends would be. 