### PR TITLE
Removing pyclamd from attachments

### DIFF
--- a/attachments/exceptions.py
+++ b/attachments/exceptions.py
@@ -1,14 +1,13 @@
-class VirusFoundException(Exception):
-    """Exception raised for detecting a virus in a file upload"""
-    pass
 
 class InvalidExtensionException(Exception):
     """Exception raised for an attachment with an invalid extension"""
     pass
 
+
 class InvalidFileTypeException(Exception):
     """Exception raised for an attachment of an invalid type"""
     pass
+
 
 class FileSizeException(Exception):
     """Exception raised for an attachment that is too large"""

--- a/attachments/models.py
+++ b/attachments/models.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from django.utils.safestring import mark_safe
 
 from attachments.signals import attachments_attached
-from attachments.utils import JSONField, get_context_key, get_default_path, get_storage, import_class, sizeof_fmt, Centos7ClamdUnixSocket
+from attachments.utils import JSONField, get_context_key, get_default_path, get_storage, import_class, sizeof_fmt
 from attachments.exceptions import VirusFoundException, InvalidExtensionException, InvalidFileTypeException, FileSizeException
 
 import os
@@ -309,21 +309,6 @@ class Session (models.Model):
         # max_file_size can be None (which means any size is allowed)
         if max_file_size and upload.file_size > max_file_size:
             raise FileSizeException("File is too large to be uploaded, file cannot be greater than {}".format(sizeof_fmt(max_file_size)))
-
-        if getattr(settings, 'ATTACHMENTS_CLAMD', False):
-            # We should explore moving this import in the future
-            import pyclamd
-            clamd_network_settings = getattr(settings, 'ATTACHMENTS_CLAMD_NETWORK_SETTINGS', {})
-            # If network settings are provided we use them to establish a socket connection
-            if clamd_network_settings:
-                # ClamdNetworkSocket accepts 'host', 'port', and 'timeout' as keys in ATTACHMENTS_CLAMD_NETWORK_SETTINGS
-                cd = pyclamd.ClamdNetworkSocket(**clamd_network_settings)
-            else:
-                cd = Centos7ClamdUnixSocket(filename=getattr(settings, 'ATTACHMENTS_CLAMD_UNIX_SOCKET_LOCATION', None))
-            virus = cd.scan_file(upload.file_path)
-            if virus is not None:
-                raise VirusFoundException('**WARNING** virus: "{}" found in the file: "{}", could not upload!'.format(virus[upload.file_path][1], upload.file_name))
-
 
 class Upload (models.Model):
     session = models.ForeignKey(Session, related_name='uploads', on_delete=models.CASCADE)

--- a/attachments/models.py
+++ b/attachments/models.py
@@ -9,7 +9,7 @@ from django.utils.safestring import mark_safe
 
 from attachments.signals import attachments_attached
 from attachments.utils import JSONField, get_context_key, get_default_path, get_storage, import_class, sizeof_fmt
-from attachments.exceptions import VirusFoundException, InvalidExtensionException, InvalidFileTypeException, FileSizeException
+from attachments.exceptions import InvalidExtensionException, InvalidFileTypeException, FileSizeException
 
 import os
 import magic

--- a/attachments/utils.py
+++ b/attachments/utils.py
@@ -8,7 +8,6 @@ from django.db import IntegrityError, models
 from django.http import Http404, HttpResponse
 from django.utils.module_loading import import_string
 from os.path import exists
-from pyclamd import ClamdUnixSocket
 from urllib.parse import quote
 from django.apps import apps
 import importlib
@@ -112,14 +111,6 @@ def import_class(fq_name):
     module_name, class_name = fq_name.rsplit('.', 1)
     mod = importlib.import_module(module_name)
     return getattr(mod, class_name)
-
-
-class Centos7ClamdUnixSocket(ClamdUnixSocket):
-    def __init__(self, filename=None, timeout=None):
-        centos_7_socket = '/var/run/clamd.scan/clamd.sock'
-        if not filename and exists(centos_7_socket):
-            filename = centos_7_socket
-        super().__init__(filename, timeout)
 
 
 def is_ajax(request):

--- a/attachments/views.py
+++ b/attachments/views.py
@@ -18,7 +18,7 @@ from .exceptions import FileSizeException, InvalidExtensionException, InvalidFil
 from .forms import PropertyForm
 from .models import Attachment, Session, Upload
 from .signals import file_download, file_uploaded, virus_detected
-from .utils import Centos7ClamdUnixSocket, ajax_only, get_storage, sizeof_fmt, url_filename, user_has_access, get_template_path
+from .utils import ajax_only, get_storage, sizeof_fmt, url_filename, user_has_access, get_template_path
 
 from datetime import datetime
 from io import BytesIO
@@ -142,28 +142,6 @@ class AttachView(ContextMixin, View):
             raise FileSizeException(
                 f"File is too large to be uploaded, file cannot be greater than { sizeof_fmt(max_file_size) }"
             )
-
-    def scan_clamd(self, path):
-        """
-        This function validates the file is free of viruses (if CLAMD is configured)
-        """
-
-        if getattr(settings, 'ATTACHMENTS_CLAMD', False):
-            # We should explore moving this import in the future
-            import pyclamd
-
-            clamd_network_settings = getattr(settings, 'ATTACHMENTS_CLAMD_NETWORK_SETTINGS', {})
-            # If network settings are provided we use them to establish a socket connection
-            if clamd_network_settings:
-                # ClamdNetworkSocket accepts 'host', 'port', and 'timeout' as keys in ATTACHMENTS_CLAMD_NETWORK_SETTINGS
-                cd = pyclamd.ClamdNetworkSocket(**clamd_network_settings)
-            else:
-                cd = Centos7ClamdUnixSocket(filename=getattr(settings, 'ATTACHMENTS_CLAMD_UNIX_SOCKET_LOCATION', None))
-            virus = cd.scan_file(path)
-            if virus is not None:
-                raise VirusFoundException(
-                    f'**WARNING** virus: "{virus[path][1]}" found in the file: "{self.file.name}", could not upload!'
-                )
 
     def set_session_data(self):
         # Update the data for this session (includes all form data for the attachments)

--- a/attachments/views.py
+++ b/attachments/views.py
@@ -188,7 +188,6 @@ class AttachView(ContextMixin, View):
 
             self.validate_extension(path)
             self.validate_max_size()
-            self.scan_clamd(path)
 
             upload = self.create_upload(path)
             self.set_session_data()

--- a/attachments/views.py
+++ b/attachments/views.py
@@ -1,7 +1,6 @@
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.core.files.move import file_move_safe
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models import Q
 from django.http import Http404, HttpResponse, JsonResponse, StreamingHttpResponse
@@ -14,13 +13,12 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.base import ContextMixin
 import magic
 
-from .exceptions import FileSizeException, InvalidExtensionException, InvalidFileTypeException, VirusFoundException
+from .exceptions import FileSizeException, InvalidExtensionException, InvalidFileTypeException
 from .forms import PropertyForm
 from .models import Attachment, Session, Upload
-from .signals import file_download, file_uploaded, virus_detected
+from .signals import file_download, file_uploaded
 from .utils import ajax_only, get_storage, sizeof_fmt, url_filename, user_has_access, get_template_path
 
-from datetime import datetime
 from io import BytesIO
 from pathlib import Path
 from wsgiref.util import FileWrapper
@@ -152,36 +150,6 @@ class AttachView(ContextMixin, View):
                 self.session.data = {key: value}
         self.session.save()
 
-    def handle_virus_found(self, upload, ex):
-        user = getattr(self.request, 'user', "Unknown user")
-        filename = upload.file_name
-        # If ATTACHMENTS_QUARANTINE_PATH is set, move the offending file to the quarantine, otherwise delete
-        attachments_quarantine_path = getattr(settings, 'ATTACHMENTS_QUARANTINE_PATH', None)
-        if attachments_quarantine_path:
-            quarantine_path = os.path.join(attachments_quarantine_path, os.path.basename(upload.file_path))
-            file_move_safe(os.path.basename(upload.file_path), quarantine_path)
-            quarantine_msg = f'File has been quarantined here: {quarantine_path}'
-        else:
-            os.remove(upload.file_path)
-            quarantine_path = None
-            quarantine_msg = 'File has been removed from the system'
-
-        error_msg = force_str(ex)
-        time_of_upload = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-        log_message = f"{error_msg} - Uploaded by {user} at {time_of_upload}. {quarantine_msg}."
-        logger.exception(log_message)
-
-        virus_detected.send(
-            sender=upload,
-            user=user,
-            filename=filename,
-            exception=ex,
-            time_of_upload=time_of_upload,
-            quarantine_path=quarantine_path,
-        )
-
-        return JsonResponse({'ok': False, 'error': error_msg}, content_type=self.content_type)
-
     def handle_file_upload(self, request, *args, **kwargs):
         try:
             path = self.create_tmp_file()
@@ -202,8 +170,6 @@ class AttachView(ContextMixin, View):
         # These errors have helpful messages, so we return them
         except (InvalidExtensionException, InvalidFileTypeException, FileSizeException) as ex:
             return JsonResponse({'ok': False, 'error': force_str(ex)}, content_type=self.content_type)
-        except VirusFoundException as ex:
-            return self.handle_virus_found(upload, ex)
         except ValidationError as ex:
             return JsonResponse({'ok': False, 'error': force_str(ex.message)}, content_type=self.content_type)
         except Exception:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -56,12 +56,8 @@ Quickstart Guide
         
 6. Set the ``ATTACHMENT_TEMP_DIR`` setting to the temporary directory you would like files to save in a settings file
 
-7. (OPTIONAL) If you have the clamav daemon running on your server set ``ATTACHMENTS_CLAMD`` to true in a settings file. NOTE: This currently only works for linux servers and the path to the clam socket will need to be set in /etc/clamav/clamd.conf or /etc/clamd.conf for this to work.
+7. (OPTIONAL) If you would like to limit the the file types users are able to upload set ``ATTACHMENTS_ALLOWED_FILE_TYPES`` to a list or tuple of mimetypes in a settings file. IE: ALLOWED_FILE_TYPES = ['text/html'] (allowing only html files. You can also just set it to the the text after the first '/' as in [html]. Note that for some files like excel they have mimetypes like `application/vnd.ms-excel` so make sure that you check the mimetypes you want before setting them!
 
-8. (OPTIONAL) If ``ATTACHMENTS_CLAMD`` is True then ``ATTACHMENTS_QUARANTINE_PATH`` can be set. Files found with a virus will be moved to that location. If this is not set the offending file will be deleted from the system.
+8. (OPTIONAL) If you would like to set a maximum file size that users are able to upload set ``ATTACHMENTS_MAX_FILE_SIZE_BYTES`` to an int of the maximum bytes you would like to allow. Default: Maximum size of 50MB = 52428800 NOTES: This is BINARY bytes NOT decimal and 'None' is a valid value (any upload size will be accepted).
 
-9. (OPTIONAL) If you would like to limit the the file types users are able to upload set ``ATTACHMENTS_ALLOWED_FILE_TYPES`` to a list or tuple of mimetypes in a settings file. IE: ALLOWED_FILE_TYPES = ['text/html'] (allowing only html files. You can also just set it to the the text after the first '/' as in [html]. Note that for some files like excel they have mimetypes like `application/vnd.ms-excel` so make sure that you check the mimetypes you want before setting them!
-
-10. (OPTIONAL) If you would like to set a maximum file size that users are able to upload set ``ATTACHMENTS_MAX_FILE_SIZE_BYTES`` to an int of the maximum bytes you would like to allow. Default: Maximum size of 50MB = 52428800 NOTES: This is BINARY bytes NOT decimal and 'None' is a valid value (any upload size will be accepted).
-
-11. (OPTIONAL) If you are allowing ``.zip`` files to be uploaded, and would like the contents of the ``.zip`` file to be attached instead of the ``.zip`` file itself, set ``ATTACHMENTS_UNPACK_ZIP_FILES`` to ``True`` in a settings file. You may also pass ``unpack_zip_files=True|False`` to an ``attachments.session()`` call to set the behavior for a specific view.
+9. (OPTIONAL) If you are allowing ``.zip`` files to be uploaded, and would like the contents of the ``.zip`` file to be attached instead of the ``.zip`` file itself, set ``ATTACHMENTS_UNPACK_ZIP_FILES`` to ``True`` in a settings file. You may also pass ``unpack_zip_files=True|False`` to an ``attachments.session()`` call to set the behavior for a specific view.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "pyclamd",
     "python-magic-bin;platform_system==\"Windows\"",
     "python-magic;platform_system!=\"Windows\"",
 ]


### PR DESCRIPTION
…level support #4779

Removing pyclamd from everywhere its used in attachments. See bioshare issue 4779 for why.